### PR TITLE
Don't use the now-removed callback parameter in the read_until_regex function

### DIFF
--- a/motioneye/utils/rtsp.py
+++ b/motioneye/utils/rtsp.py
@@ -138,7 +138,13 @@ def test_rtsp_url(data: dict) -> 'Future[GetCamerasResponse]':
         if check_error():
             return
 
-        stream.read_until_regex(b'Server: .*', on_server)
+        future = stream.read_until_regex(b'Server: .*')
+
+        def f(f):
+            on_server(f.result())
+
+        future.add_done_callback(f)
+        
         timeout[0] = io_loop.add_timeout(datetime.timedelta(seconds=1), on_server)
 
     def on_server(data=None):


### PR DESCRIPTION
Just a small change I had to make to get network cameras working at all on my machine!